### PR TITLE
[tutorials] change main to master in git clone google colab

### DIFF
--- a/tutorials/01_Check_and_update_csv_files.ipynb
+++ b/tutorials/01_Check_and_update_csv_files.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "6c481791",
    "metadata": {
@@ -12,7 +11,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "95aea466",
    "metadata": {
@@ -28,7 +26,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "6f0fc779",
    "metadata": {
@@ -39,7 +36,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "416536e6",
    "metadata": {},
@@ -71,7 +67,7 @@
     "    print(\"Running in Colab...\")\n",
     "\n",
     "    # Clone repo\n",
-    "    !git clone --recurse-submodules -b main https://github.com/ocean-data-factory-sweden/kso.git\n",
+    "    !git clone --recurse-submodules -b master https://github.com/ocean-data-factory-sweden/kso.git\n",
     "    %pip install -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/yolov5/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/kso_utils/requirements.txt)\n",
     "\n",
     "    # Fix libmagic issue\n",
@@ -97,7 +93,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "03c8011e",
    "metadata": {},
@@ -139,7 +134,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "1940bb1d",
    "metadata": {},
@@ -161,7 +155,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "488b4f09",
    "metadata": {},
@@ -186,7 +179,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "52f976b8",
    "metadata": {
@@ -197,7 +189,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "988528fa",
    "metadata": {},
@@ -219,7 +210,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ZT3fYTkRhJx1",
    "metadata": {
@@ -230,7 +220,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f2cc0872",
    "metadata": {},
@@ -252,7 +241,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a4a34d35",
    "metadata": {},
@@ -278,7 +266,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c7dc777c",
    "metadata": {},
@@ -301,7 +288,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "81f8d3c7",
    "metadata": {},
@@ -324,7 +310,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "4b134a5c",
    "metadata": {
@@ -335,7 +320,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "00941548",
    "metadata": {},
@@ -357,7 +341,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "CtTfD4tF6ouw",
    "metadata": {
@@ -368,7 +351,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "415ba69c",
    "metadata": {},
@@ -390,7 +372,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "zOyenRrL5oFK",
    "metadata": {
@@ -401,7 +382,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "64d58da6",
    "metadata": {},
@@ -423,7 +403,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "dd74715d",
    "metadata": {},
@@ -445,7 +424,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "795ca9cb",
    "metadata": {},
@@ -469,7 +447,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "eTe97bOn4790",
    "metadata": {
@@ -480,7 +457,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "02fc6c46",
    "metadata": {},
@@ -504,7 +480,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "7fc0c8f3",
    "metadata": {},
@@ -529,7 +504,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a6907d4f",
    "metadata": {},
@@ -553,7 +527,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d62d629d",
    "metadata": {},
@@ -575,7 +548,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "tyKSJHRq3kog",
    "metadata": {
@@ -586,7 +558,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f7ab1e66",
    "metadata": {},
@@ -608,7 +579,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "yKpoX8DUvHDs",
    "metadata": {
@@ -619,7 +589,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "68a13491",
    "metadata": {},
@@ -643,7 +612,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "71af5650",
    "metadata": {},
@@ -670,7 +638,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a662bb0a",
    "metadata": {},
@@ -694,7 +661,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "684a4c6e",
    "metadata": {},

--- a/tutorials/02_Upload_new_footage.ipynb
+++ b/tutorials/02_Upload_new_footage.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "7331d0cf",
    "metadata": {
@@ -12,7 +11,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "95aea466",
    "metadata": {
@@ -28,7 +26,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "6f0fc779",
    "metadata": {
@@ -39,7 +36,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d8a79964",
    "metadata": {},
@@ -74,7 +70,7 @@
     "    print(\"Running in Colab...\")\n",
     "\n",
     "    # Clone repo\n",
-    "    !git clone --recurse-submodules -b main https://github.com/ocean-data-factory-sweden/kso.git\n",
+    "    !git clone --recurse-submodules -b master https://github.com/ocean-data-factory-sweden/kso.git\n",
     "    %pip install -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/yolov5/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/kso_utils/requirements.txt)\n",
     "\n",
     "    # Fix libmagic issue\n",
@@ -100,7 +96,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "507932d4",
    "metadata": {},
@@ -141,7 +136,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "77996901",
    "metadata": {
@@ -174,7 +168,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "46c3d19e",
    "metadata": {
@@ -204,7 +197,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b8816b76",
    "metadata": {
@@ -235,7 +227,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "1a9ffb27",
    "metadata": {
@@ -302,7 +293,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f401dba3",
    "metadata": {
@@ -313,7 +303,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "18hzxd8bFxZy",
    "metadata": {
@@ -348,7 +337,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "siCS6I-5RnT2",
    "metadata": {
@@ -371,7 +359,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ZPKJ7ZovR86O",
    "metadata": {
@@ -396,7 +383,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "pK_CZFhmj0bn",
    "metadata": {
@@ -424,7 +410,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "5a9faf7c",
    "metadata": {
@@ -448,7 +433,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "08a5b78d",
    "metadata": {
@@ -479,7 +463,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "098afca0",
    "metadata": {
@@ -490,7 +473,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "21e2d0b9",
    "metadata": {

--- a/tutorials/03_Upload_clips_to_Zooniverse.ipynb
+++ b/tutorials/03_Upload_clips_to_Zooniverse.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "2c8790f3",
    "metadata": {
@@ -12,7 +11,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b169b8d0",
    "metadata": {
@@ -26,7 +24,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3ee20d67",
    "metadata": {
@@ -37,7 +34,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3a54a7be",
    "metadata": {
@@ -75,7 +71,7 @@
     "    print(\"Running in Colab...\")\n",
     "\n",
     "    # Clone repo\n",
-    "    !git clone --recurse-submodules -b main https://github.com/ocean-data-factory-sweden/kso.git\n",
+    "    !git clone --recurse-submodules -b master https://github.com/ocean-data-factory-sweden/kso.git\n",
     "    %pip install -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/yolov5/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/kso_utils/requirements.txt)\n",
     "\n",
     "    # Fix libmagic issue\n",
@@ -101,7 +97,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "32582de9",
    "metadata": {
@@ -150,7 +145,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ca98de2e",
    "metadata": {
@@ -188,7 +182,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "925539de",
    "metadata": {
@@ -222,7 +215,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b78239ab",
    "metadata": {
@@ -255,7 +247,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "fbc6e6c7",
    "metadata": {
@@ -283,7 +274,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "lq8kiRqqnxe8",
    "metadata": {
@@ -310,7 +300,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "bf1717bd",
    "metadata": {
@@ -344,7 +333,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f66ae4ff",
    "metadata": {
@@ -369,7 +357,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "QQKQ25Rd7zid",
    "metadata": {
@@ -459,7 +446,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a9NhZKK-NS_s",
    "metadata": {
@@ -514,7 +500,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d3d89365",
    "metadata": {
@@ -538,7 +523,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "dp4F7oNfRIbA",
    "metadata": {
@@ -588,7 +572,7 @@
   },
   "gpuClass": "standard",
   "kernelspec": {
-   "display_name": "odf_test",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -602,7 +586,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.9.13"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/tutorials/04_Upload_frames_to_Zooniverse.ipynb
+++ b/tutorials/04_Upload_frames_to_Zooniverse.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "2793278f",
    "metadata": {
@@ -12,7 +11,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b169b8d0",
    "metadata": {
@@ -26,7 +24,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "TDr0IZT3RBxv",
    "metadata": {
@@ -46,7 +43,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3ee20d67",
    "metadata": {
@@ -57,7 +53,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "bNHyxTD3xiA8",
    "metadata": {
@@ -90,7 +85,7 @@
     "    print(\"Running in Colab...\")\n",
     "\n",
     "    # Clone repo\n",
-    "    !git clone --recurse-submodules -b main https://github.com/ocean-data-factory-sweden/kso.git\n",
+    "    !git clone --recurse-submodules -b master https://github.com/ocean-data-factory-sweden/kso.git\n",
     "    %pip install -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/yolov5/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/kso_utils/requirements.txt)\n",
     "\n",
     "    # Fix libmagic issue\n",
@@ -116,7 +111,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "896f0873",
    "metadata": {
@@ -161,7 +155,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "ed55216d",
    "metadata": {
@@ -199,7 +192,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "EtgPfWF_ay_T",
    "metadata": {
@@ -222,7 +214,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "183a06c2",
    "metadata": {
@@ -259,7 +250,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3b0aee25",
    "metadata": {
@@ -329,7 +319,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "8e73da0c",
    "metadata": {
@@ -353,7 +342,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "powerful-scout",
    "metadata": {
@@ -364,7 +352,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "plain-senior",
    "metadata": {
@@ -406,7 +393,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "odf_test",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -420,7 +407,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/tutorials/05_Train_ML_models.ipynb
+++ b/tutorials/05_Train_ML_models.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "ndyiMLRu0DKX"
@@ -14,7 +13,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "6PSmaig62oa5"
@@ -26,7 +24,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "ZnLWmifv0DKf"
@@ -36,7 +33,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "AzQrwtLa0DKh"
@@ -67,7 +63,7 @@
     "    print(\"Running in Colab...\")\n",
     "\n",
     "    # Clone repo\n",
-    "    !git clone --recurse-submodules -b main https://github.com/ocean-data-factory-sweden/kso.git\n",
+    "    !git clone --recurse-submodules -b master https://github.com/ocean-data-factory-sweden/kso.git\n",
     "    %pip install -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/yolov5/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/kso_utils/requirements.txt)\n",
     "\n",
     "    # Fix libmagic issue\n",
@@ -108,7 +104,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -152,7 +147,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "mcFpT7njzfGw"
@@ -162,7 +156,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "ZZWAWkVZzfGr"
@@ -228,7 +221,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "m7EK4BXjzfGu"
@@ -238,7 +230,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "ex5GT5Yh441Q"
@@ -262,7 +253,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "015UUPk20DKt"
@@ -284,7 +274,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "abOQdClg0DKu"
@@ -305,7 +294,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "rTb9DFFWzfGw"
@@ -315,7 +303,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "AfQGfcMs5u1E"
@@ -351,7 +338,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "zMWSPHTt0DKv"
@@ -361,7 +347,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "HNQELgtzBQNR"
@@ -412,7 +397,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "PRXru5arzfGw"
@@ -422,7 +406,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "jYD0QFv9D0Td"
@@ -458,7 +441,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "j20Vv9JQaFcW"
@@ -485,7 +467,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "5VGC_NMazfGx"
@@ -495,7 +476,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "2aAs-KOU0DKx"
@@ -530,7 +510,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "NYprwoWN0DKy"
@@ -564,7 +543,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "id": "Aw0uBxYV0DKy"
@@ -591,7 +569,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "odf_test",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -605,7 +583,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/tutorials/06_Evaluate_ML_Models.ipynb
+++ b/tutorials/06_Evaluate_ML_Models.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "hawaiian-ratio",
    "metadata": {},
@@ -13,7 +12,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "recovered-hamburg",
    "metadata": {},
@@ -22,7 +20,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "fe8756c2",
    "metadata": {},
@@ -51,7 +48,7 @@
     "    print(\"Running in Colab...\")\n",
     "\n",
     "    # Clone repo\n",
-    "    !git clone --recurse-submodules -b main https://github.com/ocean-data-factory-sweden/kso.git\n",
+    "    !git clone --recurse-submodules -b master https://github.com/ocean-data-factory-sweden/kso.git\n",
     "    %pip install -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/yolov5/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/kso_utils/requirements.txt)\n",
     "\n",
     "    # Fix libmagic issue\n",
@@ -96,7 +93,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "be10ade2",
    "metadata": {},
@@ -138,7 +134,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "4085ec1a",
    "metadata": {},
@@ -189,7 +184,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "1d3f913f",
    "metadata": {},
@@ -198,7 +192,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d5ece376",
    "metadata": {},
@@ -217,7 +210,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "53aa7102",
    "metadata": {},
@@ -391,7 +383,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0da9e74f",
    "metadata": {},

--- a/tutorials/07_Transfer_ML_Models.ipynb
+++ b/tutorials/07_Transfer_ML_Models.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f2a13cb6",
    "metadata": {},
@@ -13,7 +12,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "fb7086d8",
    "metadata": {},
@@ -22,7 +20,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "fe4b192f",
    "metadata": {},
@@ -51,7 +48,7 @@
     "    print(\"Running in Colab...\")\n",
     "\n",
     "    # Clone repo\n",
-    "    !git clone --recurse-submodules -b main https://github.com/ocean-data-factory-sweden/kso.git\n",
+    "    !git clone --recurse-submodules -b master https://github.com/ocean-data-factory-sweden/kso.git\n",
     "    %pip install -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/yolov5/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/kso_utils/requirements.txt)\n",
     "\n",
     "    # Fix libmagic issue\n",
@@ -93,7 +90,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d518cf56",
    "metadata": {},
@@ -135,7 +131,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "7497042d",
    "metadata": {},
@@ -144,7 +139,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "b659c287",
    "metadata": {},
@@ -195,7 +189,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "dba5bf33",
    "metadata": {},
@@ -214,7 +207,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d2c05c2b",
    "metadata": {},
@@ -233,7 +225,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "9655516a",
    "metadata": {},
@@ -252,7 +243,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "8a5ea0d3",
    "metadata": {},
@@ -261,7 +251,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "d143cf17",
    "metadata": {},
@@ -281,7 +270,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c89f49a6",
    "metadata": {},
@@ -300,7 +288,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0dd7c527",
    "metadata": {},
@@ -319,7 +306,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "1b034361",
    "metadata": {},
@@ -338,7 +324,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "69e7fd98",
    "metadata": {},
@@ -357,7 +342,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "eafdf3e9",
    "metadata": {},
@@ -422,7 +406,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "odf_test",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -436,7 +420,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/tutorials/08_Analyse_Aggregate_Zooniverse_Annotations.ipynb
+++ b/tutorials/08_Analyse_Aggregate_Zooniverse_Annotations.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "5c7ec5c0",
    "metadata": {
@@ -12,7 +11,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a49ece9a",
    "metadata": {
@@ -28,7 +26,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "TbIaPdBSU_H3",
    "metadata": {
@@ -51,7 +48,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "FlVXYRkEzfGq",
    "metadata": {
@@ -62,7 +58,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "5f9faa9c",
    "metadata": {},
@@ -93,7 +88,7 @@
     "    print(\"Running in Colab...\")\n",
     "\n",
     "    # Clone repo\n",
-    "    !git clone --recurse-submodules -b main https://github.com/ocean-data-factory-sweden/kso.git\n",
+    "    !git clone --recurse-submodules -b master https://github.com/ocean-data-factory-sweden/kso.git\n",
     "    %pip install -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/yolov5/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/kso_utils/requirements.txt)\n",
     "\n",
     "    # Fix libmagic issue\n",
@@ -119,7 +114,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "472e7d6e",
    "metadata": {},
@@ -162,7 +156,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "2eda3296",
    "metadata": {},
@@ -182,7 +175,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "242d5780",
    "metadata": {},
@@ -208,7 +200,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3bd01d49",
    "metadata": {},
@@ -231,7 +222,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "q-pVC53krSRx",
    "metadata": {
@@ -242,7 +232,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "cd4adb06",
    "metadata": {},
@@ -266,7 +255,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "c00b1d6e",
    "metadata": {},
@@ -285,7 +273,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "5ac82d8a",
    "metadata": {},
@@ -312,7 +299,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "NtRz3kE-7_FV",
    "metadata": {
@@ -323,7 +309,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "R00g9V9yjWPX",
    "metadata": {
@@ -334,7 +319,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "7696340b",
    "metadata": {},
@@ -355,7 +339,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "833afcd6",
    "metadata": {},
@@ -379,7 +362,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "qnYyF5TH9INf",
    "metadata": {
@@ -390,7 +372,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "1iI7Jv5KjWPX",
    "metadata": {
@@ -401,7 +382,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "43fd5f8f",
    "metadata": {},
@@ -423,7 +403,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "30c9cb53",
    "metadata": {},
@@ -445,7 +424,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "5fe0823c",
    "metadata": {},
@@ -467,7 +445,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0136ef4b",
    "metadata": {},
@@ -491,7 +468,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f3aJWaZR9lk6",
    "metadata": {
@@ -502,7 +478,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "Q4XNdjhhzfGw",
    "metadata": {
@@ -513,7 +488,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "RkHzQIzxzfGu",
    "metadata": {
@@ -535,7 +509,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f2db50c3",
    "metadata": {},
@@ -555,7 +528,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "aa4d6059",
    "metadata": {},
@@ -575,7 +547,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "767ddf48",
    "metadata": {},
@@ -600,7 +571,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "Mw_ZiNtVKyMA",
    "metadata": {
@@ -612,7 +582,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "82302fe5",
    "metadata": {},
@@ -636,7 +605,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "iLAB5SCh9ma_",
    "metadata": {
@@ -648,7 +616,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "6127cdf4",
    "metadata": {},
@@ -682,7 +649,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "df42eac0",
    "metadata": {},

--- a/tutorials/09_Download_processed_Zooniverse_classifications.ipynb
+++ b/tutorials/09_Download_processed_Zooniverse_classifications.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "f6cb2a73",
    "metadata": {
@@ -13,7 +12,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "a49ece9a",
    "metadata": {
@@ -29,7 +27,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "dafbcdb0",
    "metadata": {
@@ -40,7 +37,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "Jo6KchvJZYKM",
    "metadata": {
@@ -73,7 +69,7 @@
     "    print(\"Running in Colab...\")\n",
     "\n",
     "    # Clone repo\n",
-    "    !git clone --recurse-submodules -b main https://github.com/ocean-data-factory-sweden/kso.git\n",
+    "    !git clone --recurse-submodules -b master https://github.com/ocean-data-factory-sweden/kso.git\n",
     "    %pip install -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/yolov5_tracker/yolov5/requirements.txt) -qr <(sed '/Pillow/d;/ipywidgets/d' kso/kso_utils/requirements.txt)\n",
     "\n",
     "    # Fix libmagic issue\n",
@@ -133,7 +129,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "117139c9",
    "metadata": {
@@ -156,7 +151,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "r0wRpx18bAx0",
    "metadata": {
@@ -183,7 +177,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "2dU3-A-yfQeP",
    "metadata": {
@@ -215,7 +208,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "TLzNMyd9buvn",
    "metadata": {
@@ -341,7 +333,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3.8.8 ('odf')",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -355,7 +347,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8 | packaged by conda-forge | (default, Feb 20 2021, 16:12:38) \n[Clang 11.0.1 ]"
+   "version": "3.9.13"
   },
   "vscode": {
    "interpreter": {


### PR DESCRIPTION
The notebooks contain a git clone for in case we use google colab. there it should clone the master branch. All notebooks now refered to main, which was in the old repository structure the name of the main/master branch. But since it is now master, all clone comments are adjusted.