### PR TITLE
[build-and-test-container] add check-strategy + fix syntax if statement

### DIFF
--- a/.github/workflows/build-and-test-container.yml
+++ b/.github/workflows/build-and-test-container.yml
@@ -49,13 +49,32 @@ jobs:
             echo "tag=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
           fi
         shell: bash
-        
+
+  check-strategy:
+    # This is for the case where we want to update the code in the master container, while nothing else to the container has changed. 
+    # NOTE THAT THIS IS A HACK! The way this gets updated now, is by adding an extra layer to the container with the new code. The old layer of code still exists and this will cause the image size to increase. However, this is an easy solution for now and it is unknown how much the image size increases. So for now we will leave it like this. More info on how to avoid this Hack is in issue #244.
+    runs-on: ubuntu-latest
+    needs: [check-image, changed-files]
+    outputs:
+      strategy: ${{ steps.build-strategy.outputs.strategy }}
+    steps:
+      - name: Determine Build Strategy
+        id: build-strategy
+        run: |
+          if [ "${{ needs.changed-files.outputs.changed }}" = "true" ] ; then
+            echo "strategy=rebuild" >> "$GITHUB_OUTPUT"
+          else
+            echo "strategy=update" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+               
        
   build-and-push-image:
     runs-on: ubuntu-latest
-    needs: [changed-files, check-image]
+    needs: [changed-files, check-image, check-strategy]
     # We always want to update image master on a push, so that the code in the container on SNIC is up to date
-    if: needs.changed-files.outputs.changed == 'true' || "${{ github.ref_name }}" = "master" 
+    # if: ${{ needs.changed-files.outputs.changed == 'true' || github.ref_name == 'master' }}
+    # HACK: WHEN WE HAVE A STABLE MASTER, UNCOMMENT THE LINE ABOVE!! THE COMMENT IS TEMPORARY SO THAT EMIL CAN TEST THINGS OUT ON DEV
     permissions:
       contents: read
       packages: write
@@ -74,14 +93,33 @@ jobs:
           registry: ghcr.io
           username: '${{ github.actor }}'
           password: '${{ secrets.GITHUB_TOKEN }}'
-      - name: Build and push
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ needs.check-image.outputs.tag }}
-            ghcr.io/${{ github.repository }}:latest
+      
+      - name: Build Docker Image
+        # It will only go into the else statement, when we build a new container for master when nothing to the docker environment has changed.
+        # In that case we only want to update the code inside of the container. NOTE THAT THIS IS A HACK, see explanation above.
+        run: |
+          if [[ "${{ needs.check-strategy.outputs.strategy }}" == "rebuild" ]] ; then
+            docker build \
+              -t ghcr.io/${{ github.repository }}:${{ needs.check-image.outputs.tag }} \
+              -t ghcr.io/${{ github.repository }}:latest .
+          else
+            echo "FROM ghcr.io/${{ github.repository }}:${{ needs.check-image.outputs.tag }}" > Dockerfile.update
+            echo "COPY . ./kso" >> Dockerfile.update
+            docker pull ghcr.io/${{ github.repository }}:latest
+            docker build \
+              -t ghcr.io/${{ github.repository }}:${{ needs.check-image.outputs.tag }} \
+              -t ghcr.io/${{ github.repository }}:latest \
+              -f Dockerfile.update .
+          fi
+          
+        # For future, after docker file is optimized more, in the first if statement, add:
+        # docker pull ghcr.io/${{ github.repository }}:${{ needs.check-image.outputs.tag }}
+        # This is to reuse layers. 
+
+
+      - name: Push Docker Image
+        run: docker push ghcr.io/${{ github.repository }}:${{ needs.check-image.outputs.tag }}
+
 
   # Get the gitlab runner id to be able to checkout the repository.
   # Otherwise you do not have permission.


### PR DESCRIPTION
    [build-and-test-container] add check-strategy + fix syntax

    This commit contains 2 things:
    * Correct the syntax of the if statement in the build docker part. Also,
      this if statement is now temporarily commented out, see notion below.
    * Add check-strategy: The logic is that when nothing has been changed to
      the docker/requirement files, we want to update the master docker so
      that it contains the correct code, but we do not want to rebuild the
      whole docker image, since this takes a lot of time. This check
      strategy allows for that optimisation, by returning update instead of
      rebuild. The build-and-push action is then replaced by the two
      separate steps, where we can pull in the current docker image and copy
      in the new code.
      NOTE THAT THIS IS AN HACK. It causes the image size to increase every
      time we update an image. However, it might be the fastest solution and
      for now it is the easies. See issue #244 for more info.

      Also note that currently, since the if-statement is commented out, this
      happens for all branches, which is what we want to speed up the
      process of creating new docker environments for Emil to test things
      out. After the Notion below is resolved, this will only happen for the
      master image.

    NOTE:
    When we move to a stable master branch and Emil does not need to test
    things anymore on the dev branch, we need to add back in the if
    statement in the build, so that we only rebuild on changes or when we
    push to master.
