### PR TITLE
fix: use the right choose_species arguments

### DIFF
--- a/test/widget-tests.py
+++ b/test/widget-tests.py
@@ -49,7 +49,7 @@ def test_select_movie():
 
 
 def test_choose_species():
-    widget = kso_widgets.choose_species(project=pp.project)
+    widget = kso_widgets.choose_species(db_connection=pp.db_connection)
     assert widget.value == ("Banded weedfish",)
 
 

--- a/tutorials/04_Upload_frames_to_Zooniverse.ipynb
+++ b/tutorials/04_Upload_frames_to_Zooniverse.ipynb
@@ -365,7 +365,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pp.species_of_interest = kso_widgets.choose_species(pp.aggregated_zoo_classifications)"
+    "pp.species_of_interest = kso_widgets.choose_species(\n",
+    "    pp.db_connection, pp.aggregated_zoo_classifications[\"label\"].unique()\n",
+    ")"
    ]
   },
   {


### PR DESCRIPTION
I modified the choose_species function in the test and tut#4 and #8 so that it matches the option to retrieve from db or a predefined list