### PR TITLE
Add Cloudina paths to avoid SNIC hardcoded

### DIFF
--- a/kso_utils/tutorials_utils.py
+++ b/kso_utils/tutorials_utils.py
@@ -673,8 +673,14 @@ def view_subject(subject_id: int, class_df: pd.DataFrame, subject_type: str):
             temp_image_path = "temp.jpg"
         except:
             # Specify volume allocated by SNIC
-            snic_path = "/mimer/NOBACKUP/groups/snic2021-6-9"
-            temp_image_path = f"{snic_path}/tmp_dir/temp.jpg"
+            if Path("/mimer").exists():
+                snic_tmp_path = "/mimer/NOBACKUP/groups/snic2021-6-9/tmp_dir"
+            elif Path("/tmp").exists() and not Path("/mimer").exists():
+                snic_tmp_path = "/tmp"
+            else:
+                logging.error("No suitable writable path found.")
+                return
+            temp_image_path = str(Path(snic_tmp_path, "temp.jpg"))
 
         finally:
             # Remove temporary file
@@ -1366,10 +1372,16 @@ def create_clips(
 
     # Specify output path for zooniverse clip extraction
     if project.server == "SNIC":
-        temp_path = "/mimer/NOBACKUP/groups/snic2021-6-9/"
+        if Path("/mimer").exists():
+            temp_path = "/mimer/NOBACKUP/groups/snic2021-6-9/tmp_dir"
+        elif Path("/tmp").exists() and not Path("/mimer").exists():
+            temp_path = "/tmp"
+        else:
+            logging.error("No suitable writable path found.")
+            return
     else:
         temp_path = "."
-    clips_folder = str(Path(temp_path, "tmp_dir", movies_selected + "_zooniverseclips"))
+    clips_folder = str(Path(temp_path, movies_selected + "_zooniverseclips"))
 
     # Set the filename of the clips
     potential_start_df["clip_filename"] = (
@@ -1441,10 +1453,16 @@ def create_modified_clips(
 
     # Specify output path for modified clip extraction
     if project.server == "SNIC":
-        temp_path = "/mimer/NOBACKUP/groups/snic2021-6-9/"
+        if Path("/mimer").exists():
+            temp_path = "/mimer/NOBACKUP/groups/snic2021-6-9/tmp_dir"
+        elif Path("/tmp").exists() and not Path("/mimer").exists():
+            temp_path = "/tmp"
+        else:
+            logging.error("No suitable writable path found.")
+            return
     else:
         temp_path = "."
-    mod_clips_folder = str(Path(temp_path, "tmp_dir", mod_clip_folder))
+    mod_clips_folder = str(Path(temp_path, mod_clip_folder))
 
     # Remove existing modified clips
     if os.path.exists(mod_clips_folder):

--- a/kso_utils/zooniverse_utils.py
+++ b/kso_utils/zooniverse_utils.py
@@ -1586,14 +1586,20 @@ def extract_frames_for_zoo(
 
     # Specify the temp location to store the frames
     temp_frames_folder = "_".join(species_list) + "_frames/"
+    # Make sure that folder names do not exceed a certain length
     if len(temp_frames_folder) > 260:
         curr = datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S")
         temp_frames_folder = f"{curr}_various_frames/"
 
     if project.server == "SNIC":
         # Specify volume allocated by SNIC
-        snic_path = "/mimer/NOBACKUP/groups/snic2021-6-9"
-        folder_name = f"{snic_path}/tmp_dir/frames/"
+        if Path("/mimer").exists():
+            folder_name = "/mimer/NOBACKUP/groups/snic2021-6-9/tmp_dir/frames"
+        elif Path("/tmp").exists() and not Path("/mimer").exists():
+            folder_name = "/tmp/frames"
+        else:
+            logging.error("No suitable writable path found.")
+            return
         frames_folder = str(Path(folder_name, temp_frames_folder))
     else:
         frames_folder = temp_frames_folder
@@ -1710,8 +1716,13 @@ def modify_frames(
     # Specify the folder to host the modified frames
     if project.server == "SNIC":
         # Specify volume allocated by SNIC
-        snic_path = "/mimer/NOBACKUP/groups/snic2021-6-9"
-        folder_name = Path(snic_path, "tmp_dir", "frames")
+        if Path("/mimer").exists():
+            folder_name = "/mimer/NOBACKUP/groups/snic2021-6-9/tmp_dir/frames"
+        elif Path("/tmp").exists() and not Path("/mimer").exists():
+            folder_name = "/tmp/frames"
+        else:
+            logging.error("No suitable writable path found.")
+            return
         mod_frames_folder = str(
             Path(folder_name, "modified_" + "_".join(species_i) + "_frames/")
         )


### PR DESCRIPTION
Allow for Cloudina paths by not using /mimer for every temp file path in SNIC. 