### PR TITLE
Install KSO in the container images

### DIFF
--- a/containers/final/Dockerfile
+++ b/containers/final/Dockerfile
@@ -18,6 +18,26 @@ RUN adduser --disabled-password \
 COPY --chown=${NB_UID}:${NB_UID} . /opt/kso
 RUN chmod +x /opt/kso/containers/entrypoint.sh
 
+# Install KSO (all dependencies should be satisfied already)
+ARG PIP_BREAK_SYSTEM_PACKAGES=1
+ARG PIP_ROOT_USER_ACTION=ignore
+ARG PIP_NO_CACHE_DIR=1
+RUN pip install --no-deps /opt/kso[dev]
+
+# Check that all dependencies are satisfied
+RUN pip check || { \
+    echo ""; \
+    echo "ERROR: Installed dependencies failed validation."; \
+    echo ""; \
+    echo "This means that requirements.txt used for containers is inconsistent with pyproject.toml."; \
+    echo ""; \
+    echo "If you changed dependencies in pyproject.toml, update requirements.txt too."; \
+    echo ""; \
+    echo "Dependency issues reported by 'pip check':"; \
+    pip check; \
+    exit 1; \
+}
+
 # Set run environment
 USER ${NB_USER}
 WORKDIR /opt/kso

--- a/containers/requirements.txt
+++ b/containers/requirements.txt
@@ -255,12 +255,12 @@ tinycss2==1.4.0
 tokenize-rt==6.2.0
 tokenizers==0.22.2
 tomlkit==0.13.3
-torch==2.8.0
+torch==2.9.1
 torch-flops==0.4.1
 torch-summary==1.4.5
 torchinfo==1.8.0
 torchscan==0.1.1
-torchvision==0.23.0
+torchvision==0.24.1
 tornado==6.5.4
 tqdm==4.67.1
 traitlets==5.14.3

--- a/containers/requirements.txt
+++ b/containers/requirements.txt
@@ -91,6 +91,7 @@ huggingface-hub==0.24.7
 humanfriendly==10.0
 idna==3.7
 imageio==2.37.2
+imageio-ffmpeg==0.6.0
 imagesize==1.4.1
 importlib-metadata==8.7.0
 ipyfilechooser==0.6.0

--- a/containers/requirements_cpu.txt
+++ b/containers/requirements_cpu.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.8.0+cpu
-torchvision==0.23.0+cpu
+torch==2.9.1+cpu
+torchvision==0.24.1+cpu

--- a/containers/requirements_cuda12.9.txt
+++ b/containers/requirements_cuda12.9.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://download.pytorch.org/whl/cu129
-torch==2.8.0+cu129
-torchvision==0.23.0+cu129
+torch==2.9.1+cu129
+torchvision==0.24.1+cu129

--- a/containers/requirements_rocm6.4.txt
+++ b/containers/requirements_rocm6.4.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://download.pytorch.org/whl/rocm6.4
-torch==2.8.0+rocm6.4
-torchvision==0.23.0+rocm6.4
+torch==2.9.1+rocm6.4
+torchvision==0.24.1+rocm6.4


### PR DESCRIPTION
This PR will install KSO in the final container image.

This means that `import kso` will use the KSO from the container image by default. One can still set `PYTHONPATH=.../kso/src` to override the version inside the container (useful for development).

In addition, pytorch is updated to 2.9.1 to match with the updates in `pyproject.toml`.

Also, a consistency check between `pyproject.toml` and `requirements.txt` is added, example error message when they are not in sync:

```txt
ERROR: Installed dependencies failed validation.

This means that requirements.txt used for containers is inconsistent with pyproject.toml.

If you changed dependencies in pyproject.toml, update requirements.txt too.

Dependency issues reported by 'pip check':
kso 0.1.0 requires imageio-ffmpeg, which is not installed.
```


Closes #515.