### PR TITLE
Fix MIOpen environment variables for LUMI

### DIFF
--- a/contrib/lumi/README.md
+++ b/contrib/lumi/README.md
@@ -82,6 +82,11 @@ CONTAINER="/projappl/project_.../containers/kso_dev-rocm6.4-ubuntu24.04.sif"
 export SINGULARITY_BIND="/pfs,/scratch,/projappl,/project,/flash,/appl"
 export python="singularity exec $CONTAINER python3"
 export PYTHONUSERBASE="/scratch/$PROJECT/$USER/venv"
+
+# Set MIOpen paths
+export MIOPEN_CUSTOM_CACHE_DIR="/tmp/$USER/miopen-cache"
+export MIOPEN_USER_DB_PATH="/tmp/$USER/miopen-db"
+mkdir -p "$MIOPEN_CUSTOM_CACHE_DIR" "$MIOPEN_USER_DB_PATH"
 ```
 
 ### 3. Connect and navigate

--- a/contrib/lumi/scripts/submit.lumi.sh
+++ b/contrib/lumi/scripts/submit.lumi.sh
@@ -18,10 +18,10 @@ echo "Using $CONTAINER"
 export SINGULARITY_BIND="/pfs,/scratch,/projappl,/project,/flash,/appl"
 export PYTHONUSERBASE="/scratch/$PROJECT/$USER/venv"
 
-export MIOPEN_USER_DB_PATH="/tmp/$USER/miopen-cache"
-export MIOPEN_CUSTOM_CACHE_DIR=${MIOPEN_USER_DB_PATH}
-rm -rf ${MIOPEN_USER_DB_PATH}
-mkdir -p ${MIOPEN_USER_DB_PATH}
+# Set MIOpen paths
+export MIOPEN_CUSTOM_CACHE_DIR="/tmp/$USER/miopen-cache"
+export MIOPEN_USER_DB_PATH="/tmp/$USER/miopen-db"
+mkdir -p "$MIOPEN_CUSTOM_CACHE_DIR" "$MIOPEN_USER_DB_PATH"
 
 KSO_PATH=$(readlink -f ../../)
 export PYTHONPATH=$KSO_PATH${PYTHONPATH:+:$PYTHONPATH}

--- a/contrib/lumi/scripts/submit.lumi.sh
+++ b/contrib/lumi/scripts/submit.lumi.sh
@@ -24,8 +24,6 @@ export MIOPEN_USER_DB_PATH="/tmp/$USER/miopen-db"
 mkdir -p "$MIOPEN_CUSTOM_CACHE_DIR" "$MIOPEN_USER_DB_PATH"
 
 KSO_PATH=$(readlink -f ../../)
-export PYTHONPATH=$KSO_PATH${PYTHONPATH:+:$PYTHONPATH}
-
 notebook=$KSO_PATH/notebooks/analyse/Train_models.ipynb
 dpath="outputs/$SLURM_JOB_ID"
 python="singularity exec $CONTAINER python3"

--- a/src/kso/project.py
+++ b/src/kso/project.py
@@ -24,8 +24,6 @@ import shutil
 
 # settings.reset()
 os.environ["MLFLOW_TRACKING_URI"] = "http://your-server:5000"
-os.environ["MIOPEN_DEBUG_DISABLE_FIND_DB"] = "1"
-os.environ["MIOPEN_DISABLE_CACHE"] = "1"
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"


### PR DESCRIPTION
This PR will document `MIOPEN_CUSTOM_CACHE_DIR` and `MIOPEN_USER_DB_PATH` for LUMI and remove `MIOPEN_DEBUG_DISABLE_FIND_DB` and `MIOPEN_DISABLE_CACHE` from project.py.